### PR TITLE
Support multi resource type

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -16,6 +16,6 @@ jobs:
             ${{ runner.os }}-go-
       - uses: golangci/golangci-lint-action@v1
         with:
-          version: v1.27
+          version: v1.28
       - name: Run tests
         run: go test -race -v ./...

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,5 +1,5 @@
 name: Build
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,3 +5,5 @@ linters:
   disable:
     - goerr113
     - maligned
+    - gofumpt
+    - gomnd

--- a/pkg/cmd/describe.go
+++ b/pkg/cmd/describe.go
@@ -148,8 +148,6 @@ func (o *DescribeOptions) Run(ctx context.Context, args []string) error {
 		NamespaceParam(o.Namespace).DefaultNamespace().AllNamespaces(o.AllNamespaces).
 		LabelSelectorParam(o.Selector).
 		ResourceTypeOrNameArgs(true, o.BuilderArgs...).
-		//nolint:godox
-		SingleResourceType(). // TODO: Support multi resource type
 		Flatten().
 		Do()
 

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const Version = "v1.2.0"
+const Version = "v1.3.0"
 
 var Revision = "development" //nolint:gochecknoglobals
 


### PR DESCRIPTION
`fuzzy describe` command now allows multiple resource types to be entered.

It is displayed with the following rules:

```go
"%s/%s (%s)", Lower(GroupKind), Name, Namespace
```

for example:

```
kubectl fuzzy describe service,configmap -n argocd
```

<img width="317" alt="Screen Shot 2020-07-11 at 1 47 03" src="https://user-images.githubusercontent.com/34958495/87178653-705d1000-c318-11ea-9a4d-6a88a038b4f9.png">