### PR TITLE
Support global flags

### DIFF
--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -11,8 +11,8 @@ import (
 )
 
 // NewCmdCreate provides a cobra command wrapping CreateOptions.
-func NewCmdCreate(streams genericclioptions.IOStreams) *cobra.Command {
-	o := NewCreateOptions(streams)
+func NewCmdCreate(config *genericclioptions.ConfigFlags, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewCreateOptions(config, streams)
 
 	cmd := &cobra.Command{
 		Use:           "create",
@@ -28,7 +28,7 @@ func NewCmdCreate(streams genericclioptions.IOStreams) *cobra.Command {
 	o.configFlags.AddFlags(flags)
 	o.AddFlags(flags)
 
-	cmd.AddCommand(NewCmdCreateJob(streams))
+	cmd.AddCommand(NewCmdCreateJob(config, streams))
 
 	return cmd
 }
@@ -42,9 +42,9 @@ type CreateOptions struct {
 }
 
 // NewCreateOptions provides an instance of CreateOptions with default values.
-func NewCreateOptions(streams genericclioptions.IOStreams) *CreateOptions {
+func NewCreateOptions(config *genericclioptions.ConfigFlags, streams genericclioptions.IOStreams) *CreateOptions {
 	return &CreateOptions{
-		configFlags: genericclioptions.NewConfigFlags(true),
+		configFlags: config,
 		printFlags:  genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		IOStreams:   streams,
 	}

--- a/pkg/cmd/create_job.go
+++ b/pkg/cmd/create_job.go
@@ -30,8 +30,8 @@ const (
 )
 
 // NewCmdCreateJob provides a cobra command wrapping CreateJobOptions.
-func NewCmdCreateJob(streams genericclioptions.IOStreams) *cobra.Command {
-	o := NewCreateJobOptions(streams)
+func NewCmdCreateJob(config *genericclioptions.ConfigFlags, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewCreateJobOptions(config, streams)
 
 	cmd := &cobra.Command{
 		Use:           "job [NAME] --from=cronjob",
@@ -86,9 +86,9 @@ type CreateJobOptions struct {
 }
 
 // NewCreateJobOptions provides an instance of CreateJobOptions with default values.
-func NewCreateJobOptions(streams genericclioptions.IOStreams) *CreateJobOptions {
+func NewCreateJobOptions(config *genericclioptions.ConfigFlags, streams genericclioptions.IOStreams) *CreateJobOptions {
 	return &CreateJobOptions{
-		configFlags:       genericclioptions.NewConfigFlags(true),
+		configFlags:       config,
 		previewPrintFlags: genericclioptions.NewJSONYamlPrintFlags(),
 		printFlags:        genericclioptions.NewPrintFlags("created").WithTypeSetter(scheme.Scheme),
 		IOStreams:         streams,

--- a/pkg/cmd/describe.go
+++ b/pkg/cmd/describe.go
@@ -23,8 +23,8 @@ const (
 )
 
 // NewCmdDescribe provides a cobra command wrapping DescribeOptions.
-func NewCmdDescribe(streams genericclioptions.IOStreams) *cobra.Command {
-	o := NewDescribeOptions(streams)
+func NewCmdDescribe(config *genericclioptions.ConfigFlags, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewDescribeOptions(config, streams)
 
 	cmd := &cobra.Command{
 		Use:           "describe",
@@ -49,9 +49,7 @@ func NewCmdDescribe(streams genericclioptions.IOStreams) *cobra.Command {
 		},
 	}
 
-	flags := cmd.Flags()
-	o.configFlags.AddFlags(flags)
-	o.AddFlags(flags)
+	o.AddFlags(cmd.Flags())
 
 	return cmd
 }
@@ -99,9 +97,9 @@ func (o *DescribeOptions) AddFlags(flags *pflag.FlagSet) {
 }
 
 // NewDescribeOptions provides an instance of DescribeOptions with default values.
-func NewDescribeOptions(streams genericclioptions.IOStreams) *DescribeOptions {
+func NewDescribeOptions(config *genericclioptions.ConfigFlags, streams genericclioptions.IOStreams) *DescribeOptions {
 	return &DescribeOptions{
-		configFlags: genericclioptions.NewConfigFlags(true),
+		configFlags: config,
 		printFlags:  genericclioptions.NewJSONYamlPrintFlags(),
 		IOStreams:   streams,
 		describerSettings: &describe.DescriberSettings{

--- a/pkg/cmd/exec.go
+++ b/pkg/cmd/exec.go
@@ -30,8 +30,8 @@ const (
 )
 
 // NewCmdExec provides a cobra command wrapping ExecOptions.
-func NewCmdExec(streams genericclioptions.IOStreams) *cobra.Command {
-	o := NewExecOptions(streams)
+func NewCmdExec(config *genericclioptions.ConfigFlags, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewExecOptions(config, streams)
 
 	cmd := &cobra.Command{
 		Use:           "exec",
@@ -58,9 +58,7 @@ func NewCmdExec(streams genericclioptions.IOStreams) *cobra.Command {
 		},
 	}
 
-	flags := cmd.Flags()
-	o.configFlags.AddFlags(flags)
-	o.AddFlags(flags)
+	o.AddFlags(cmd.Flags())
 
 	return cmd
 }
@@ -118,12 +116,12 @@ func (o *ExecOptions) AddFlags(flags *pflag.FlagSet) {
 }
 
 // NewExecOptions provides an instance of ExecOptions with default values.
-func NewExecOptions(streams genericclioptions.IOStreams) *ExecOptions {
+func NewExecOptions(config *genericclioptions.ConfigFlags, streams genericclioptions.IOStreams) *ExecOptions {
 	return &ExecOptions{
 		streamOptions: streamOptions{
 			IOStreams: streams,
 		},
-		configFlags: genericclioptions.NewConfigFlags(true),
+		configFlags: config,
 		printFlags:  genericclioptions.NewJSONYamlPrintFlags(),
 	}
 }

--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -28,8 +28,8 @@ const (
 )
 
 // NewCmdLogs provides a cobra command wrapping LogsOptions.
-func NewCmdLogs(streams genericclioptions.IOStreams) *cobra.Command {
-	o := NewLogsOptions(streams)
+func NewCmdLogs(config *genericclioptions.ConfigFlags, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewLogsOptions(config, streams)
 
 	cmd := &cobra.Command{
 		Use:           "logs",
@@ -54,9 +54,7 @@ func NewCmdLogs(streams genericclioptions.IOStreams) *cobra.Command {
 		},
 	}
 
-	flags := cmd.Flags()
-	o.configFlags.AddFlags(flags)
-	o.AddFlags(flags)
+	o.AddFlags(cmd.Flags())
 
 	return cmd
 }
@@ -120,9 +118,9 @@ func (o *LogsOptions) AddFlags(flags *pflag.FlagSet) {
 }
 
 // NewLogsOptions provides an instance of LogsOptions with default values.
-func NewLogsOptions(streams genericclioptions.IOStreams) *LogsOptions {
+func NewLogsOptions(flags *genericclioptions.ConfigFlags, streams genericclioptions.IOStreams) *LogsOptions {
 	return &LogsOptions{
-		configFlags: genericclioptions.NewConfigFlags(true),
+		configFlags: flags,
 		printFlags:  genericclioptions.NewJSONYamlPrintFlags(),
 		IOStreams:   streams,
 	}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -20,16 +20,28 @@ func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 		},
 	}
 
-	return AddSubCmd(cmd, streams)
+	globalConfig := &globalConfig{
+		configFlags: genericclioptions.NewConfigFlags(true),
+		streams:     streams,
+	}
+
+	globalConfig.configFlags.AddFlags(cmd.PersistentFlags())
+
+	return AddSubCmd(cmd, globalConfig)
+}
+
+type globalConfig struct {
+	configFlags *genericclioptions.ConfigFlags
+	streams     genericclioptions.IOStreams
 }
 
 // AddSubCmd to be added sub command for root command.
-func AddSubCmd(cmd *cobra.Command, streams genericclioptions.IOStreams) *cobra.Command {
-	cmd.AddCommand(NewCmdLogs(streams))
-	cmd.AddCommand(NewCmdExec(streams))
-	cmd.AddCommand(NewCmdDescribe(streams))
+func AddSubCmd(cmd *cobra.Command, config *globalConfig) *cobra.Command {
+	cmd.AddCommand(NewCmdLogs(config.configFlags, config.streams))
+	cmd.AddCommand(NewCmdExec(config.configFlags, config.streams))
+	cmd.AddCommand(NewCmdDescribe(config.configFlags, config.streams))
+	cmd.AddCommand(NewCmdCreate(config.configFlags, config.streams))
 	cmd.AddCommand(NewCmdVersion())
-	cmd.AddCommand(NewCmdCreate(streams))
 
 	return cmd
 }


### PR DESCRIPTION
Show the common command flags as global flags.

## After

```console
$ kubectl fuzzy logs -h
Selecting a Pod with the fuzzy finder and view the log

Usage:
  kubectl-fuzzy logs [flags]

Examples:

	# Selecting a Pod with the fuzzy finder and view the log
	kubectl fuzzy logs [flags]


Flags:
  -A, --all-namespaces          If present, list the requested object(s) across all namespaces.Namespace in current context is ignored even if specified with --namespace.
  -f, --follow                  Specify if the logs should be streamed.
  -h, --help                    help for logs
      --limit-bytes int         Maximum bytes of logs to return. Defaults to no limit.
  -P, --preview                 If true, display the object YAML|JSON by preview window for fuzzy finder selector.
      --preview-format string   Preview window output format. One of json|yaml. (default "yaml")
  -p, --previous                If true, print the logs for the previous instance of the container in a pod if it exists.
      --raw-preview             If true, display the unsimplified object in the preview window. (default is simplified)
      --since duration          Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs.Only one of since-time / since may be used.
      --since-time string       Only return logs after a specific date (RFC3339). Defaults to all logs.Only one of since-time / since may be used.
      --tail int                Lines of recent log file to display. Defaults to -1 with no selector,showing all log lines otherwise 10, if a selector is provided. (default -1)
      --timestamps              Include timestamps on each line in the log output.

Global Flags:
      --as string                      Username to impersonate for the operation
      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --cache-dir string               Default cache directory (default "/Users/d-kuro/.kube/cache")
      --certificate-authority string   Path to a cert file for the certificate authority
      --client-certificate string      Path to a client certificate file for TLS
      --client-key string              Path to a client key file for TLS
      --cluster string                 The name of the kubeconfig cluster to use
      --context string                 The name of the kubeconfig context to use
      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
  -n, --namespace string               If present, the namespace scope for this CLI request
      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -s, --server string                  The address and port of the Kubernetes API server
      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
      --token string                   Bearer token for authentication to the API server
      --user string                    The name of the kubeconfig user to use
```

## Before

```console
$ kubectl fuzzy logs -h
Selecting a Pod with the fuzzy finder and view the log

Usage:
  kubectl-fuzzy logs [flags]

Examples:

	# Selecting a Pod with the fuzzy finder and view the log
	kubectl fuzzy logs [flags]


Flags:
  -A, --all-namespaces                 If present, list the requested object(s) across all namespaces.Namespace in current context is ignored even if specified with --namespace.
      --as string                      Username to impersonate for the operation
      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --cache-dir string               Default HTTP cache directory (default "/Users/d-kuro/.kube/http-cache")
      --certificate-authority string   Path to a cert file for the certificate authority
      --client-certificate string      Path to a client certificate file for TLS
      --client-key string              Path to a client key file for TLS
      --cluster string                 The name of the kubeconfig cluster to use
      --context string                 The name of the kubeconfig context to use
  -f, --follow                         Specify if the logs should be streamed.
  -h, --help                           help for logs
      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
      --limit-bytes int                Maximum bytes of logs to return. Defaults to no limit.
  -n, --namespace string               If present, the namespace scope for this CLI request
  -P, --preview                        If true, display the object YAML|JSON by preview window for fuzzy finder selector.
      --preview-format string          Preview window output format. One of json|yaml. (default "yaml")
  -p, --previous                       If true, print the logs for the previous instance of the container in a pod if it exists.
      --raw-preview                    If true, display the unsimplified object in the preview window. (default is simplified)
      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -s, --server string                  The address and port of the Kubernetes API server
      --since duration                 Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs.Only one of since-time / since may be used.
      --since-time string              Only return logs after a specific date (RFC3339). Defaults to all logs.Only one of since-time / since may be used.
      --tail int                       Lines of recent log file to display. Defaults to -1 with no selector,showing all log lines otherwise 10, if a selector is provided. (default -1)
      --timestamps                     Include timestamps on each line in the log output.
      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
      --token string                   Bearer token for authentication to the API server
      --user string                    The name of the kubeconfig user to use
```