### PR TITLE
Support delete command

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,12 @@ Usage:
 
 Available Commands:
   create      Create a resource
-  describe    Selecting a object with the fuzzy finder and show details
+  delete      Selecting an object with the fuzzy finder and delete
+  describe    Selecting an object with the fuzzy finder and show details
   exec        Selecting a Pod with the fuzzy finder and execute a command in a container
   help        Help about any command
   logs        Selecting a Pod with the fuzzy finder and view the log
   version     Show version
-
-Flags:
-  -h, --help   help for kubectl-fuzzy
 
 Use "kubectl-fuzzy [command] --help" for more information about a command.
 ```
@@ -73,6 +71,7 @@ Use "kubectl-fuzzy [command] --help" for more information about a command.
 * [x] `kubectl exec`
 * [x] `kubectl describe`
 * [x] `kubectl create job --from=cronjob`
+* [x] `kubectl delete`
 * anything else...
 
 > 📝 See the [documentation](./docs/commands.md) for support commands.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,6 +1,7 @@
 # Support Commands
 
 * [kubectl create](#create)
+* [kubectl delete](#delete)
 * [kubectl describe](#describe)
 * [kubectl logs](#logs)
 * [kubectl exec](#exec)
@@ -12,6 +13,71 @@ Compatibility commands with `kubectl create`.
 Available Commands:
 
 * `kubectl fuzzy create job`
+
+## Delete
+
+Compatibility commands with `kubectl delete`.
+
+Usage:
+
+```console
+$ kubectl fuzzy delete TYPE [flags]
+```
+
+Helps:
+
+<details>
+
+```console
+$ kubectl fuzzy delete -h
+Selecting an object with the fuzzy finder and delete
+
+Usage:
+  kubectl-fuzzy delete [flags]
+
+Examples:
+
+	# Selecting an object with the fuzzy finder and delete
+	kubectl fuzzy delete TYPE [flags]
+
+
+Flags:
+  -A, --all-namespaces                 If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
+      --cascade                        If true, cascade the deletion of the resources managed by this resource (e.g. Pods created by a ReplicationController). Default true. (default true)
+      --dry-run string[="unchanged"]   Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource. (default "none")
+      --field-selector string          Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2).The server only supports a limited number of field queries per type.
+      --force                          If true, immediately remove resources from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.
+      --grace-period int               Period of time in seconds given to the resource to terminate gracefully. Ignored if negative. Set to 1 for immediate shutdown. Can only be set to 0 when --force is true (force deletion). (default -1)
+  -h, --help                           help for delete
+      --now                            If true, resources are signaled for immediate shutdown (same as --grace-period=1).
+  -o, --output string                  Output mode. Use "-o name" for shorter output (resource/name).
+  -P, --preview                        If true, display the object YAML|JSON by preview window for fuzzy finder selector.
+      --preview-format string          Preview window output format. One of json|yaml. (default "yaml")
+      --raw-preview                    If true, display the unsimplified object in the preview window. (default is simplified)
+  -l, --selector string                Selector (label query) to filter on, not including uninitialized ones.
+      --timeout duration               The length of time to wait before giving up on a delete, zero means determine a timeout from the size of the object
+      --wait                           If true, wait for resources to be gone before returning. This waits for finalizers. (default true)
+
+Global Flags:
+      --as string                      Username to impersonate for the operation
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --cache-dir string               Default cache directory (default "/Users/d-kuro/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
+```
+
+</details>
 
 ### Job
 
@@ -48,28 +114,29 @@ Examples:
 
 
 Flags:
+      --from string             The name of the resource to create a Job from (only cronjob is supported).
+  -h, --help                    help for job
+  -P, --preview                 If true, display the object YAML|JSON by preview window for fuzzy finder selector.
+      --preview-format string   Preview window output format. One of json|yaml. (default "yaml")
+      --raw-preview             If true, display the unsimplified object in the preview window. (default is simplified)
+
+Global Flags:
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default HTTP cache directory (default "/Users/d-kuro/.kube/http-cache")
+      --cache-dir string               Default cache directory (default "/Users/d-kuro/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
       --context string                 The name of the kubeconfig context to use
-      --from string                    The name of the resource to create a Job from (only cronjob is supported).
-  -h, --help                           help for job
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string               If present, the namespace scope for this CLI request
-  -P, --preview                        If true, display the object YAML|JSON by preview window for fuzzy finder selector.
-      --preview-format string          Preview window output format. One of json|yaml. (default "yaml")
-      --raw-preview                    If true, display the unsimplified object in the preview window. (default is simplified)
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
-
 ```
 
 </details>
@@ -90,41 +157,43 @@ Helps:
 
 ```console
 $ kubectl fuzzy describe -h
-Selecting a object with the fuzzy finder and show details
-  
-  Usage:
-    kubectl-fuzzy describe [flags]
-  
-  Examples:
-  
-          # Selecting a Object with the fuzzy finder and view the log and show details
-          kubectl fuzzy describe TYPE [flags]
-  
-  
-  Flags:
-    -A, --all-namespaces                 If present, list the requested object(s) across all namespaces.Namespace in current context is ignored even if specified with --namespace.
-        --as string                      Username to impersonate for the operation
-        --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-        --cache-dir string               Default HTTP cache directory (default "/Users/d-kuro/.kube/http-cache")
-        --certificate-authority string   Path to a cert file for the certificate authority
-        --client-certificate string      Path to a client certificate file for TLS
-        --client-key string              Path to a client key file for TLS
-        --cluster string                 The name of the kubeconfig cluster to use
-        --context string                 The name of the kubeconfig context to use
-    -h, --help                           help for describe
-        --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
-        --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-    -n, --namespace string               If present, the namespace scope for this CLI request
-    -P, --preview                        If true, display the object YAML|JSON by preview window for fuzzy finder selector.
-        --preview-format string          Preview window output format. One of json|yaml. (default "yaml")
-        --raw-preview                    If true, display the unsimplified object in the preview window. (default is simplified)
-        --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-    -l, --selector string                Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
-    -s, --server string                  The address and port of the Kubernetes API server
-        --show-events                    If true, display events related to the described object. (default true)
-        --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
-        --token string                   Bearer token for authentication to the API server
-        --user string                    The name of the kubeconfig user to use
+Selecting an object with the fuzzy finder and show details
+
+Usage:
+  kubectl-fuzzy describe [flags]
+
+Examples:
+
+	# Selecting an object with the fuzzy finder and view the log and show details
+	kubectl fuzzy describe TYPE [flags]
+
+
+Flags:
+  -A, --all-namespaces          If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
+  -h, --help                    help for describe
+  -P, --preview                 If true, display the object YAML|JSON by preview window for fuzzy finder selector.
+      --preview-format string   Preview window output format. One of json|yaml. (default "yaml")
+      --raw-preview             If true, display the unsimplified object in the preview window. (default is simplified)
+  -l, --selector string         Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+      --show-events             If true, display events related to the described object. (default true)
+
+Global Flags:
+      --as string                      Username to impersonate for the operation
+      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
+      --cache-dir string               Default cache directory (default "/Users/d-kuro/.kube/cache")
+      --certificate-authority string   Path to a cert file for the certificate authority
+      --client-certificate string      Path to a client certificate file for TLS
+      --client-key string              Path to a client key file for TLS
+      --cluster string                 The name of the kubeconfig cluster to use
+      --context string                 The name of the kubeconfig context to use
+      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
+      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+  -n, --namespace string               If present, the namespace scope for this CLI request
+      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
+  -s, --server string                  The address and port of the Kubernetes API server
+      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
+      --token string                   Bearer token for authentication to the API server
+      --user string                    The name of the kubeconfig user to use
 ```
 
 </details>
@@ -157,36 +226,38 @@ Usage:
 
 Examples:
 
-        # Selecting a Pod with the fuzzy finder and view the log
-        kubectl fuzzy logs [flags]
+	# Selecting a Pod with the fuzzy finder and view the log
+	kubectl fuzzy logs [flags]
 
 
 Flags:
-  -A, --all-namespaces                 If present, list the requested object(s) across all namespaces.Namespace in current context is ignored even if specified with --namespace.
+  -A, --all-namespaces          If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
+  -f, --follow                  Specify if the logs should be streamed.
+  -h, --help                    help for logs
+      --limit-bytes int         Maximum bytes of logs to return. Defaults to no limit.
+  -P, --preview                 If true, display the object YAML|JSON by preview window for fuzzy finder selector.
+      --preview-format string   Preview window output format. One of json|yaml. (default "yaml")
+  -p, --previous                If true, print the logs for the previous instance of the container in a pod if it exists.
+      --raw-preview             If true, display the unsimplified object in the preview window. (default is simplified)
+      --since duration          Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs. Only one of since-time / since may be used.
+      --since-time string       Only return logs after a specific date (RFC3339). Defaults to all logs. Only one of since-time / since may be used.
+      --tail int                Lines of recent log file to display. Defaults to -1 with no selector, showing all log lines otherwise 10, if a selector is provided. (default -1)
+      --timestamps              Include timestamps on each line in the log output.
+
+Global Flags:
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default HTTP cache directory (default "/Users/d-kuro/.kube/http-cache")
+      --cache-dir string               Default cache directory (default "/Users/d-kuro/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
       --context string                 The name of the kubeconfig context to use
-  -f, --follow                         Specify if the logs should be streamed.
-  -h, --help                           help for logs
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
-      --limit-bytes int                Maximum bytes of logs to return. Defaults to no limit.
   -n, --namespace string               If present, the namespace scope for this CLI request
-  -P, --preview                        If true, display the object YAML|JSON by preview window for fuzzy finder selector.
-      --preview-format string          Preview window output format. One of json|yaml. (default "yaml")
-  -p, --previous                       If true, print the logs for the previous instance of the container in a pod if it exists.
-      --raw-preview                    If true, display the unsimplified object in the preview window. (default is simplified)
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
-      --since duration                 Only return logs newer than a relative duration like 5s, 2m, or 3h. Defaults to all logs.Only one of since-time / since may be used.
-      --since-time string              Only return logs after a specific date (RFC3339). Defaults to all logs.Only one of since-time / since may be used.
-      --tail int                       Lines of recent log file to display. Defaults to -1 with no selector,showing all log lines otherwise 10, if a selector is provided. (default -1)
-      --timestamps                     Include timestamps on each line in the log output.
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
@@ -213,7 +284,7 @@ Helps:
 <details>
 
 ```console
-$ kubectl fuzzy exec [flags] -h
+$ kubectl fuzzy exec -h
 Selecting a Pod with the fuzzy finder and execute a command in a container
 
 Usage:
@@ -226,29 +297,31 @@ Examples:
 
 
 Flags:
-  -A, --all-namespaces                 If present, list the requested object(s) across all namespaces.Namespace in current context is ignored even if specified with --namespace.
+  -A, --all-namespaces          If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
+  -h, --help                    help for exec
+  -P, --preview                 If true, display the object YAML|JSON by preview window for fuzzy finder selector.
+      --preview-format string   Preview window output format. One of json|yaml. (default "yaml")
+      --raw-preview             If true, display the unsimplified object in the preview window. (default is simplified)
+  -l, --selector string         Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
+  -i, --stdin                   Pass stdin to the container
+  -t, --tty                     Stdin is a TTY
+
+Global Flags:
       --as string                      Username to impersonate for the operation
       --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
-      --cache-dir string               Default HTTP cache directory (default "/Users/d-kuro/.kube/http-cache")
+      --cache-dir string               Default cache directory (default "/Users/d-kuro/.kube/cache")
       --certificate-authority string   Path to a cert file for the certificate authority
       --client-certificate string      Path to a client certificate file for TLS
       --client-key string              Path to a client key file for TLS
       --cluster string                 The name of the kubeconfig cluster to use
       --context string                 The name of the kubeconfig context to use
-  -h, --help                           help for exec
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
   -n, --namespace string               If present, the namespace scope for this CLI request
-  -P, --preview                        If true, display the object YAML|JSON by preview window for fuzzy finder selector.
-      --preview-format string          Preview window output format. One of json|yaml. (default "yaml")
-      --raw-preview                    If true, display the unsimplified object in the preview window. (default is simplified)
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
-  -l, --selector string                Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)
   -s, --server string                  The address and port of the Kubernetes API server
-  -i, --stdin                          Pass stdin to the container
       --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
       --token string                   Bearer token for authentication to the API server
-  -t, --tty                            Stdin is a TTY
       --user string                    The name of the kubeconfig user to use
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	k8s.io/apimachinery v0.19.2
 	k8s.io/cli-runtime v0.19.2
 	k8s.io/client-go v0.19.2
+	k8s.io/klog/v2 v2.2.0
 	k8s.io/kubectl v0.19.2
 	sigs.k8s.io/yaml v1.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,7 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
+github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7 h1:5ZkaAPbicIKTF2I64qf5Fh8Aa83Q/dnOafMYV0OMwjA=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
@@ -175,6 +176,7 @@ github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57/go.mod h1:zfwlbNMJ+OI
 github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
 github.com/google/pprof v0.0.0-20191218002539-d4f498aebedc/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4 h1:hU4mGcQI4DaAYW+IbTun+2qEZVFxK0ySjQLTbS0VQKc=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
@@ -553,6 +555,7 @@ k8s.io/cli-runtime v0.19.2/go.mod h1:CMynmJM4Yf02TlkbhKxoSzi4Zf518PukJ5xep/NaNeY
 k8s.io/client-go v0.19.2 h1:gMJuU3xJZs86L1oQ99R4EViAADUPMHHtS9jFshasHSc=
 k8s.io/client-go v0.19.2/go.mod h1:S5wPhCqyDNAlzM9CnEdgTGV4OqhsW3jGO1UM1epwfJA=
 k8s.io/code-generator v0.19.2/go.mod h1:moqLn7w0t9cMs4+5CQyxnfA/HV8MF6aAVENF+WZZhgk=
+k8s.io/component-base v0.19.2 h1:jW5Y9RcZTb79liEhW3XDVTW7MuvEGP0tQZnfSX6/+gs=
 k8s.io/component-base v0.19.2/go.mod h1:g5LrsiTiabMLZ40AR6Hl45f088DevyGY+cCE2agEIVo=
 k8s.io/gengo v0.0.0-20200413195148-3a45101e95ac/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=
 k8s.io/gengo v0.0.0-20200428234225-8167cfdcfc14/go.mod h1:ezvh/TsK7cY6rbqRK0oQQ8IAqLxYwwyPxAX1Pzy0ii0=

--- a/pkg/cmd/create.go
+++ b/pkg/cmd/create.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"context"
-	"errors"
+	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -20,7 +20,7 @@ func NewCmdCreate(config *genericclioptions.ConfigFlags, streams genericclioptio
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(c *cobra.Command, args []string) error {
-			return errors.New("must specify resource, only supported job")
+			return fmt.Errorf("must specify resource, only supported job")
 		},
 	}
 

--- a/pkg/cmd/create_job.go
+++ b/pkg/cmd/create_job.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/d-kuro/kubectl-fuzzy/pkg/fuzzyfinder"
@@ -116,11 +115,11 @@ func (o *CreateJobOptions) Complete(cmd *cobra.Command, args []string) error {
 	}
 
 	if o.from == "" {
-		return errors.New("--from option is required, only supported job from cronjob")
+		return fmt.Errorf("--from option is required, only supported job from cronjob")
 	}
 
 	if o.from != "cronjob" {
-		return errors.New("must specify resource, only supported cronjob")
+		return fmt.Errorf("must specify resource, only supported cronjob")
 	}
 
 	if len(args) >= 1 {
@@ -172,7 +171,7 @@ func (o *CreateJobOptions) Run(ctx context.Context) error {
 	}
 
 	if len(infos) == 0 {
-		return errors.New("no resources found")
+		return fmt.Errorf("resource not found")
 	}
 
 	var printer printers.ResourcePrinter
@@ -198,7 +197,7 @@ func (o *CreateJobOptions) Run(ctx context.Context) error {
 
 	cj, ok := uncastVersionedObj.(*batchv1beta1.CronJob)
 	if !ok {
-		return errors.New("failed to cast cronjob")
+		return fmt.Errorf("failed to cast cronjob")
 	}
 
 	job := o.createJobFromCronJob(cj, &o.name)

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -31,6 +31,7 @@ func NewCmdDelete(config *genericclioptions.ConfigFlags, streams genericclioptio
 		Example:       "", // TODO
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		SuggestFor:    []string{"rm"},
 		RunE: func(c *cobra.Command, args []string) error {
 			if err := o.Complete(c, args); err != nil {
 				return err

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	exampleDelete = `
-	# Selecting a object with the fuzzy finder and delete
+	# Selecting an object with the fuzzy finder and delete
 	kubectl fuzzy delete TYPE [flags]
 `
 )
@@ -35,7 +35,7 @@ func NewCmdDelete(config *genericclioptions.ConfigFlags, streams genericclioptio
 
 	cmd := &cobra.Command{
 		Use:           "delete",
-		Short:         "Selecting a object with the fuzzy finder and delete",
+		Short:         "Selecting an object with the fuzzy finder and delete",
 		Example:       exampleDelete,
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -1,0 +1,405 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/d-kuro/kubectl-fuzzy/pkg/fuzzyfinder"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/cli-runtime/pkg/resource"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/klog/v2"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	cmdwait "k8s.io/kubectl/pkg/cmd/wait"
+)
+
+func NewCmdDelete(config *genericclioptions.ConfigFlags, streams genericclioptions.IOStreams) *cobra.Command {
+	o := NewDeleteOptions(config, streams)
+
+	cmd := &cobra.Command{
+		Use:           "delete",
+		Short:         "Selecting a object with the fuzzy finder and delete object",
+		Example:       "", // TODO
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(c *cobra.Command, args []string) error {
+			if err := o.Complete(c, args); err != nil {
+				return err
+			}
+
+			if err := o.Validate(); err != nil {
+				return err
+			}
+
+			if err := o.Run(c.Context(), args); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	o.AddFlags(cmd.Flags())
+	cmdutil.AddDryRunFlag(cmd)
+
+	return cmd
+}
+
+// DeleteOptions provides information required to update
+// the current context on a user's KUBECONFIG.
+type DeleteOptions struct {
+	configFlags *genericclioptions.ConfigFlags
+	printFlags  *genericclioptions.JSONYamlPrintFlags
+	genericclioptions.IOStreams
+
+	allNamespaces    bool
+	labelSelector    string
+	fieldSelector    string
+	cascade          bool
+	deleteNow        bool
+	forceDeletion    bool
+	waitForDeletion  bool
+	warnClusterScope bool
+
+	gracePeriod int
+	timeout     time.Duration
+
+	dryRunStrategy cmdutil.DryRunStrategy
+	dryRunVerifier *resource.DryRunVerifier
+
+	output string
+
+	dynamicClient dynamic.Interface
+	mapper        meta.RESTMapper
+	namespace     string
+
+	preview       bool
+	previewFormat string
+	rawPreview    bool
+}
+
+// AddFlags adds a flag to the flag set.
+func (o *DeleteOptions) AddFlags(flags *pflag.FlagSet) {
+	// kubectl flags
+	flags.BoolVarP(&o.allNamespaces, "all-namespaces", "A", false,
+		"If present, list the requested object(s) across all namespaces. "+
+			"Namespace in current context is ignored even if specified with --namespace.")
+	flags.BoolVar(&o.cascade, "cascade", true,
+		"If true, cascade the deletion of the resources managed by this resource "+
+			"(e.g. Pods created by a ReplicationController). Default true.")
+	flags.StringVar(&o.fieldSelector, "field-selector", "",
+		"Selector (field query) to filter on, supports '=', '==', and '!='."+
+			"(e.g. --field-selector key1=value1,key2=value2)."+
+			"The server only supports a limited number of field queries per type.")
+	flags.BoolVar(&o.forceDeletion, "force", false,
+		"If true, immediately remove resources from API and bypass graceful deletion. "+
+			"Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.")
+	flags.IntVar(&o.gracePeriod, "grace-period", -1,
+		"Period of time in seconds given to the resource to terminate gracefully. Ignored if negative. "+
+			"Set to 1 for immediate shutdown. Can only be set to 0 when --force is true (force deletion).")
+	flags.BoolVar(&o.deleteNow, "now", false,
+		"If true, resources are signaled for immediate shutdown (same as --grace-period=1).")
+	flags.StringVarP(&o.output, "output", "o", "",
+		"Output mode. Use \"-o name\" for shorter output (resource/name).")
+	flags.StringVarP(&o.labelSelector, "selector", "l", "",
+		"Selector (label query) to filter on, not including uninitialized ones.")
+	flags.DurationVar(&o.timeout, "timeout", 0*time.Second,
+		"The length of time to wait before giving up on a delete, zero means determine a timeout from the size of the object")
+	flags.BoolVar(&o.waitForDeletion, "wait", true,
+		"If true, wait for resources to be gone before returning. This waits for finalizers.")
+
+	// original flags
+	flags.BoolVarP(&o.preview, "preview", "P", false,
+		"If true, display the object YAML|JSON by preview window for fuzzy finder selector.")
+	flags.StringVar(&o.previewFormat, "preview-format", "yaml",
+		"Preview window output format. One of json|yaml.")
+	flags.BoolVar(&o.rawPreview, "raw-preview", false,
+		"If true, display the unsimplified object in the preview window. (default is simplified)")
+}
+
+// NewDeleteOptions provides an instance of DeleteOptions with default values.
+func NewDeleteOptions(config *genericclioptions.ConfigFlags, streams genericclioptions.IOStreams) *DeleteOptions {
+	return &DeleteOptions{
+		configFlags: config,
+		printFlags:  genericclioptions.NewJSONYamlPrintFlags(),
+		IOStreams:   streams,
+	}
+}
+
+// Complete sets all information required for show details.
+func (o *DeleteOptions) Complete(cmd *cobra.Command, args []string) error {
+	cmdNamespace, enforceNamespace, err := o.configFlags.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return fmt.Errorf("faild to get namespace from kube config: %w", err)
+	}
+
+	o.warnClusterScope = enforceNamespace && !o.allNamespaces
+
+	if o.deleteNow {
+		if o.gracePeriod != -1 {
+			return fmt.Errorf("--now and --grace-period cannot be specified together")
+		}
+
+		o.gracePeriod = 1
+	}
+
+	if o.gracePeriod == 0 && !o.forceDeletion {
+		// To preserve backwards compatibility, but prevent accidental data loss, we convert --grace-period=0
+		// into --grace-period=1. Users may provide --force to bypass this conversion.
+		o.gracePeriod = 1
+	}
+
+	if o.forceDeletion && o.gracePeriod < 0 {
+		o.gracePeriod = 0
+	}
+
+	o.dryRunStrategy, err = cmdutil.GetDryRunStrategy(cmd)
+	if err != nil {
+		return fmt.Errorf("faild to get dry-run strategy: %w", err)
+	}
+
+	restConfig, err := o.configFlags.ToRESTConfig()
+	if err != nil {
+		return fmt.Errorf("faild to get REST config: %w", err)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(restConfig)
+	if err != nil {
+		return fmt.Errorf("faild to create dynamic client: %w", err)
+	}
+
+	discoveryClient, err := o.configFlags.ToDiscoveryClient()
+	if err != nil {
+		return fmt.Errorf("failed to create discovery client: %w", err)
+	}
+
+	o.dryRunVerifier = resource.NewDryRunVerifier(dynamicClient, discoveryClient)
+	o.dynamicClient = dynamicClient
+	o.namespace = cmdNamespace
+
+	o.mapper, err = o.configFlags.ToRESTMapper()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Validate ensures that all required arguments and flag values are provided.
+func (o *DeleteOptions) Validate() error {
+	switch {
+	case o.gracePeriod == 0 && o.forceDeletion:
+		fmt.Fprintln(o.ErrOut,
+			"warning: Immediate deletion does not wait for confirmation that the running resource has been terminated. "+
+				"The resource may continue to run on the cluster indefinitely.")
+	case o.gracePeriod > 0 && o.forceDeletion:
+		return fmt.Errorf("--force and --grace-period greater than 0 cannot be specified together")
+	}
+
+	return nil
+}
+
+// Run execute fizzy finder and delete object.
+func (o *DeleteOptions) Run(ctx context.Context, args []string) error {
+	r := resource.NewBuilder(o.configFlags).
+		Unstructured().
+		ContinueOnError().
+		NamespaceParam(o.namespace).DefaultNamespace().
+		LabelSelectorParam(o.labelSelector).
+		FieldSelectorParam(o.fieldSelector).
+		AllNamespaces(o.allNamespaces).
+		ResourceTypeOrNameArgs(true, args...).RequireObject(false).
+		Flatten().
+		Do()
+
+	if err := r.Err(); err != nil {
+		return fmt.Errorf("failed to request: %w", err)
+	}
+
+	infos, err := r.Infos()
+	if err != nil {
+		return fmt.Errorf("failed to get infos: %w", err)
+	}
+
+	if len(infos) == 0 {
+		return fmt.Errorf("resource not found")
+	}
+
+	var printer printers.ResourcePrinter
+	if o.preview {
+		printer, err = o.printFlags.ToPrinter(o.previewFormat)
+		if err != nil {
+			return fmt.Errorf("failed to get printer: %w", err)
+		}
+	}
+
+	info, err := fuzzyfinder.Infos(infos,
+		fuzzyfinder.WithAllNamespaces(o.allNamespaces),
+		fuzzyfinder.WithPreview(printer),
+		fuzzyfinder.WithRawPreview(o.rawPreview))
+	if err != nil {
+		return fmt.Errorf("failed to fuzzyfinder execute: %w", err)
+	}
+
+	uidMap := cmdwait.UIDMap{}
+
+	options := &metav1.DeleteOptions{}
+	if o.gracePeriod >= 0 {
+		options = metav1.NewDeleteOptions(int64(o.gracePeriod))
+	}
+
+	policy := metav1.DeletePropagationBackground
+	if !o.cascade {
+		policy = metav1.DeletePropagationOrphan
+	}
+
+	options.PropagationPolicy = &policy
+
+	if o.warnClusterScope && info.Mapping.Scope.Name() == meta.RESTScopeNameRoot {
+		fmt.Fprintf(o.ErrOut, "warning: deleting cluster-scoped resources, not scoped to the provided namespace\n")
+		o.warnClusterScope = false
+	}
+
+	if o.dryRunStrategy == cmdutil.DryRunClient {
+		o.PrintObj(info)
+
+		return nil
+	}
+
+	if o.dryRunStrategy == cmdutil.DryRunServer {
+		if err := o.dryRunVerifier.HasSupport(info.Mapping.GroupVersionKind); err != nil {
+			return err
+		}
+	}
+
+	response, err := o.deleteResource(info, options)
+	if err != nil {
+		return err
+	}
+
+	resourceLocation := cmdwait.ResourceLocation{
+		GroupResource: info.Mapping.Resource.GroupResource(),
+		Namespace:     info.Namespace,
+		Name:          info.Name,
+	}
+
+	if status, ok := response.(*metav1.Status); ok && status.Details != nil {
+		uidMap[resourceLocation] = status.Details.UID
+
+		return nil
+	}
+
+	responseMetadata, err := meta.Accessor(response)
+	if err != nil {
+		// we don't have UID, but we didn't fail the delete, next best thing is just skipping the UID
+		klog.V(1).Info(err)
+
+		return nil
+	}
+
+	uidMap[resourceLocation] = responseMetadata.GetUID()
+
+	if !o.waitForDeletion {
+		return nil
+	}
+
+	// if we don't have a dynamic client, we don't want to wait.  Eventually when delete is cleaned up, this will likely
+	// drop out.
+	if o.dynamicClient == nil {
+		return nil
+	}
+
+	// If we are dry-running, then we don't want to wait
+	if o.dryRunStrategy != cmdutil.DryRunNone {
+		return nil
+	}
+
+	const defaultEffectiveTimeout = 168 * time.Hour
+
+	effectiveTimeout := o.timeout
+	if effectiveTimeout == 0 {
+		// if we requested to wait forever, set it to a week.
+		effectiveTimeout = defaultEffectiveTimeout
+	}
+
+	waitOptions := cmdwait.WaitOptions{
+		ResourceFinder: genericclioptions.ResourceFinderForResult(
+			resource.InfoListVisitor([]*resource.Info{info})),
+		UIDMap:        uidMap,
+		DynamicClient: o.dynamicClient,
+		Timeout:       effectiveTimeout,
+
+		Printer:     printers.NewDiscardingPrinter(),
+		ConditionFn: cmdwait.IsDeleted,
+		IOStreams:   o.IOStreams,
+	}
+
+	err = waitOptions.RunWait()
+	if errors.IsForbidden(err) || errors.IsMethodNotSupported(err) {
+		// if we're forbidden from waiting, we shouldn't fail.
+		// if the resource doesn't support a verb we need, we shouldn't fail.
+		klog.V(1).Info(err)
+
+		return nil
+	}
+
+	return err
+}
+
+func (o *DeleteOptions) deleteResource(info *resource.Info, options *metav1.DeleteOptions) (runtime.Object, error) {
+	deleteResponse, err := resource.
+		NewHelper(info.Client, info.Mapping).
+		DryRun(o.dryRunStrategy == cmdutil.DryRunServer).
+		DeleteWithOptions(info.Namespace, info.Name, options)
+	if err != nil {
+		return nil, cmdutil.AddSourceToErr("deleting", info.Source, err)
+	}
+
+	o.PrintObj(info)
+
+	return deleteResponse, nil
+}
+
+// PrintObj for deleted objects is special because we do not have an object to print.
+// This mirrors name printer behavior.
+func (o *DeleteOptions) PrintObj(info *resource.Info) {
+	operation := "deleted"
+	groupKind := info.Mapping.GroupVersionKind
+	kindString := fmt.Sprintf("%s.%s", strings.ToLower(groupKind.Kind), groupKind.Group)
+
+	if len(groupKind.Group) == 0 {
+		kindString = strings.ToLower(groupKind.Kind)
+	}
+
+	if o.gracePeriod == 0 {
+		operation = "force deleted"
+	}
+
+	switch o.dryRunStrategy {
+	case cmdutil.DryRunClient:
+		operation = fmt.Sprintf("%s (dry run)", operation)
+	case cmdutil.DryRunServer:
+		operation = fmt.Sprintf("%s (server dry run)", operation)
+	case cmdutil.DryRunNone:
+		break
+	}
+
+	if o.output == "name" {
+		// -o name: prints resource/name
+		fmt.Fprintf(o.Out, "%s/%s\n", kindString, info.Name)
+
+		return
+	}
+
+	// understandable output by default
+	fmt.Fprintf(o.Out, "%s \"%s\" %s\n", kindString, info.Name, operation)
+}

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -22,13 +22,21 @@ import (
 	cmdwait "k8s.io/kubectl/pkg/cmd/wait"
 )
 
+const (
+	exampleDelete = `
+	# Selecting a object with the fuzzy finder and delete
+	kubectl fuzzy delete TYPE [flags]
+`
+)
+
+// NewCmdDelete provides a cobra command wrapping DeleteOptions.
 func NewCmdDelete(config *genericclioptions.ConfigFlags, streams genericclioptions.IOStreams) *cobra.Command {
 	o := NewDeleteOptions(config, streams)
 
 	cmd := &cobra.Command{
 		Use:           "delete",
-		Short:         "Selecting a object with the fuzzy finder and delete object",
-		Example:       "", // TODO
+		Short:         "Selecting a object with the fuzzy finder and delete",
+		Example:       exampleDelete,
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		SuggestFor:    []string{"rm"},
@@ -80,7 +88,6 @@ type DeleteOptions struct {
 	output string
 
 	dynamicClient dynamic.Interface
-	mapper        meta.RESTMapper
 	namespace     string
 
 	preview       bool
@@ -186,11 +193,6 @@ func (o *DeleteOptions) Complete(cmd *cobra.Command, args []string) error {
 	o.dryRunVerifier = resource.NewDryRunVerifier(dynamicClient, discoveryClient)
 	o.dynamicClient = dynamicClient
 	o.namespace = cmdNamespace
-
-	o.mapper, err = o.configFlags.ToRESTMapper()
-	if err != nil {
-		return err
-	}
 
 	return nil
 }

--- a/pkg/cmd/describe.go
+++ b/pkg/cmd/describe.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	exampleDescribe = `
-	# Selecting a Object with the fuzzy finder and view the log and show details
+	# Selecting an object with the fuzzy finder and view the log and show details
 	kubectl fuzzy describe TYPE [flags]
 `
 )
@@ -27,7 +27,7 @@ func NewCmdDescribe(config *genericclioptions.ConfigFlags, streams genericcliopt
 
 	cmd := &cobra.Command{
 		Use:           "describe",
-		Short:         "Selecting a object with the fuzzy finder and show details",
+		Short:         "Selecting an object with the fuzzy finder and show details",
 		Example:       exampleDescribe,
 		SilenceUsage:  true,
 		SilenceErrors: true,

--- a/pkg/cmd/describe.go
+++ b/pkg/cmd/describe.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/d-kuro/kubectl-fuzzy/pkg/fuzzyfinder"
@@ -158,7 +157,7 @@ func (o *DescribeOptions) Run(ctx context.Context, args []string) error {
 	}
 
 	if len(infos) == 0 {
-		return errors.New("no resources found")
+		return fmt.Errorf("resource not found")
 	}
 
 	var printer printers.ResourcePrinter

--- a/pkg/cmd/exec.go
+++ b/pkg/cmd/exec.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -191,7 +190,7 @@ func (o *ExecOptions) Run(ctx context.Context) error {
 	}
 
 	if len(infos) == 0 {
-		return errors.New("no resources found")
+		return fmt.Errorf("resource not found")
 	}
 
 	var printer printers.ResourcePrinter
@@ -217,7 +216,7 @@ func (o *ExecOptions) Run(ctx context.Context) error {
 
 	pod, ok := uncastVersionedObj.(*corev1.Pod)
 	if !ok {
-		return errors.New("illegal types that are not pod")
+		return fmt.Errorf("illegal types that are not pod")
 	}
 
 	var containerName string

--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -175,7 +174,7 @@ func (o *LogsOptions) Run(ctx context.Context) error {
 	}
 
 	if len(infos) == 0 {
-		return errors.New("no resources found")
+		return fmt.Errorf("resource not found")
 	}
 
 	var printer printers.ResourcePrinter
@@ -201,7 +200,7 @@ func (o *LogsOptions) Run(ctx context.Context) error {
 
 	pod, ok := uncastVersionedObj.(*corev1.Pod)
 	if !ok {
-		return errors.New("illegal types that are not pod")
+		return fmt.Errorf("illegal types that are not pod")
 	}
 
 	var containerName string

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -41,6 +41,7 @@ func AddSubCmd(cmd *cobra.Command, config *globalConfig) *cobra.Command {
 	cmd.AddCommand(NewCmdExec(config.configFlags, config.streams))
 	cmd.AddCommand(NewCmdDescribe(config.configFlags, config.streams))
 	cmd.AddCommand(NewCmdCreate(config.configFlags, config.streams))
+	cmd.AddCommand(NewCmdDelete(config.configFlags, config.streams))
 	cmd.AddCommand(NewCmdVersion())
 
 	return cmd

--- a/pkg/cmd/version.go
+++ b/pkg/cmd/version.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const Version = "v1.6.1"
+const Version = "v1.7.0"
 
 var Revision = "development" //nolint:gochecknoglobals
 


### PR DESCRIPTION
## Support delete command

Added support for the `kubectl delete` command with fuzzy finder selector.
You can use the `kubectl fuzzy delete` command.

```console
$ kubectl fuzzy delete -h
Selecting an object with the fuzzy finder and delete

Usage:
  kubectl-fuzzy delete [flags]

Examples:

	# Selecting an object with the fuzzy finder and delete
	kubectl fuzzy delete TYPE [flags]


Flags:
  -A, --all-namespaces                 If present, list the requested object(s) across all namespaces. Namespace in current context is ignored even if specified with --namespace.
      --cascade                        If true, cascade the deletion of the resources managed by this resource (e.g. Pods created by a ReplicationController). Default true. (default true)
      --dry-run string[="unchanged"]   Must be "none", "server", or "client". If client strategy, only print the object that would be sent, without sending it. If server strategy, submit server-side request without persisting the resource. (default "none")
      --field-selector string          Selector (field query) to filter on, supports '=', '==', and '!='.(e.g. --field-selector key1=value1,key2=value2).The server only supports a limited number of field queries per type.
      --force                          If true, immediately remove resources from API and bypass graceful deletion. Note that immediate deletion of some resources may result in inconsistency or data loss and requires confirmation.
      --grace-period int               Period of time in seconds given to the resource to terminate gracefully. Ignored if negative. Set to 1 for immediate shutdown. Can only be set to 0 when --force is true (force deletion). (default -1)
  -h, --help                           help for delete
      --now                            If true, resources are signaled for immediate shutdown (same as --grace-period=1).
  -o, --output string                  Output mode. Use "-o name" for shorter output (resource/name).
  -P, --preview                        If true, display the object YAML|JSON by preview window for fuzzy finder selector.
      --preview-format string          Preview window output format. One of json|yaml. (default "yaml")
      --raw-preview                    If true, display the unsimplified object in the preview window. (default is simplified)
  -l, --selector string                Selector (label query) to filter on, not including uninitialized ones.
      --timeout duration               The length of time to wait before giving up on a delete, zero means determine a timeout from the size of the object
      --wait                           If true, wait for resources to be gone before returning. This waits for finalizers. (default true)

Global Flags:
      --as string                      Username to impersonate for the operation
      --as-group stringArray           Group to impersonate for the operation, this flag can be repeated to specify multiple groups.
      --cache-dir string               Default cache directory (default "/Users/d-kuro/.kube/cache")
      --certificate-authority string   Path to a cert file for the certificate authority
      --client-certificate string      Path to a client certificate file for TLS
      --client-key string              Path to a client key file for TLS
      --cluster string                 The name of the kubeconfig cluster to use
      --context string                 The name of the kubeconfig context to use
      --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
      --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
  -n, --namespace string               If present, the namespace scope for this CLI request
      --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
  -s, --server string                  The address and port of the Kubernetes API server
      --tls-server-name string         Server name to use for server certificate validation. If it is not provided, the hostname used to contact the server is used
      --token string                   Bearer token for authentication to the API server
      --user string                    The name of the kubeconfig user to use


```