### PR TITLE
Add env var to enable preview across all commands

### DIFF
--- a/pkg/cmd/create_job.go
+++ b/pkg/cmd/create_job.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/d-kuro/kubectl-fuzzy/pkg/fuzzyfinder"
 	"github.com/d-kuro/kubectl-fuzzy/pkg/kubernetes"
@@ -120,6 +121,10 @@ func (o *CreateJobOptions) Complete(cmd *cobra.Command, args []string) error {
 
 	if o.from != "cronjob" {
 		return fmt.Errorf("must specify resource, only supported cronjob")
+	}
+
+	if !o.preview {
+		o.preview = os.Getenv(previewEnabledEnvVar) == "true"
 	}
 
 	if len(args) >= 1 {

--- a/pkg/cmd/create_job.go
+++ b/pkg/cmd/create_job.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/d-kuro/kubectl-fuzzy/pkg/fuzzyfinder"
 	"github.com/d-kuro/kubectl-fuzzy/pkg/kubernetes"
@@ -124,7 +125,7 @@ func (o *CreateJobOptions) Complete(cmd *cobra.Command, args []string) error {
 	}
 
 	if !o.preview {
-		o.preview = os.Getenv(previewEnabledEnvVar) == "true"
+		o.preview, _ = strconv.ParseBool(os.Getenv(previewEnabledEnvVar))
 	}
 
 	if len(args) >= 1 {

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -152,7 +153,7 @@ func (o *DeleteOptions) Complete(cmd *cobra.Command, args []string) error {
 	}
 
 	if !o.preview {
-		o.preview = os.Getenv(previewEnabledEnvVar) == "true"
+		o.preview, _ = strconv.ParseBool(os.Getenv(previewEnabledEnvVar))
 	}
 
 	o.warnClusterScope = enforceNamespace && !o.allNamespaces

--- a/pkg/cmd/delete.go
+++ b/pkg/cmd/delete.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -148,6 +149,10 @@ func (o *DeleteOptions) Complete(cmd *cobra.Command, args []string) error {
 	cmdNamespace, enforceNamespace, err := o.configFlags.ToRawKubeConfigLoader().Namespace()
 	if err != nil {
 		return fmt.Errorf("faild to get namespace from kube config: %w", err)
+	}
+
+	if !o.preview {
+		o.preview = os.Getenv(previewEnabledEnvVar) == "true"
 	}
 
 	o.warnClusterScope = enforceNamespace && !o.allNamespaces

--- a/pkg/cmd/describe.go
+++ b/pkg/cmd/describe.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/d-kuro/kubectl-fuzzy/pkg/fuzzyfinder"
 	"github.com/spf13/cobra"
@@ -116,6 +117,10 @@ func (o *DescribeOptions) Complete(cmd *cobra.Command, args []string) error {
 	}
 
 	o.builderArgs = args
+
+	if !o.preview {
+		o.preview = os.Getenv(previewEnabledEnvVar) == "true"
+	}
 
 	if !o.allNamespaces {
 		kubeConfig := o.configFlags.ToRawKubeConfigLoader()

--- a/pkg/cmd/describe.go
+++ b/pkg/cmd/describe.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/d-kuro/kubectl-fuzzy/pkg/fuzzyfinder"
 	"github.com/spf13/cobra"
@@ -119,7 +120,7 @@ func (o *DescribeOptions) Complete(cmd *cobra.Command, args []string) error {
 	o.builderArgs = args
 
 	if !o.preview {
-		o.preview = os.Getenv(previewEnabledEnvVar) == "true"
+		o.preview, _ = strconv.ParseBool(os.Getenv(previewEnabledEnvVar))
 	}
 
 	if !o.allNamespaces {

--- a/pkg/cmd/exec.go
+++ b/pkg/cmd/exec.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strconv"
 
 	"github.com/d-kuro/kubectl-fuzzy/pkg/fuzzyfinder"
 	"github.com/d-kuro/kubectl-fuzzy/pkg/kubernetes"
@@ -148,7 +149,7 @@ func (o *ExecOptions) Complete(cmd *cobra.Command, args []string, argsLenAtDash 
 	o.builder = resource.NewBuilder(o.configFlags)
 
 	if !o.preview {
-		o.preview = os.Getenv(previewEnabledEnvVar) == "true"
+		o.preview, _ = strconv.ParseBool(os.Getenv(previewEnabledEnvVar))
 	}
 
 	if !o.allNamespaces {

--- a/pkg/cmd/exec.go
+++ b/pkg/cmd/exec.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 
 	"github.com/d-kuro/kubectl-fuzzy/pkg/fuzzyfinder"
 	"github.com/d-kuro/kubectl-fuzzy/pkg/kubernetes"
@@ -145,6 +146,10 @@ func (o *ExecOptions) Complete(cmd *cobra.Command, args []string, argsLenAtDash 
 
 	o.client = client.CoreV1()
 	o.builder = resource.NewBuilder(o.configFlags)
+
+	if !o.preview {
+		o.preview = os.Getenv(previewEnabledEnvVar) == "true"
+	}
 
 	if !o.allNamespaces {
 		kubeConfig := o.configFlags.ToRawKubeConfigLoader()

--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/d-kuro/kubectl-fuzzy/pkg/fuzzyfinder"
@@ -134,7 +135,7 @@ func (o *LogsOptions) Complete(cmd *cobra.Command, args []string) error {
 	}
 
 	if !o.preview {
-		o.preview = os.Getenv(previewEnabledEnvVar) == "true"
+		o.preview, _ = strconv.ParseBool(os.Getenv(previewEnabledEnvVar))
 	}
 
 	o.podClient = client.CoreV1()

--- a/pkg/cmd/logs.go
+++ b/pkg/cmd/logs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"time"
 
 	"github.com/d-kuro/kubectl-fuzzy/pkg/fuzzyfinder"
@@ -130,6 +131,10 @@ func (o *LogsOptions) Complete(cmd *cobra.Command, args []string) error {
 	client, err := kubernetes.NewClient(o.configFlags)
 	if err != nil {
 		return fmt.Errorf("failed to new Kubernetes client: %w", err)
+	}
+
+	if !o.preview {
+		o.preview = os.Getenv(previewEnabledEnvVar) == "true"
 	}
 
 	o.podClient = client.CoreV1()

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -5,6 +5,10 @@ import (
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
+const (
+	previewEnabledEnvVar = "KUBE_FUZZY_PREVIEW_ENABLED"
+)
+
 // NewCmdRoot return a cobra root command.
 func NewCmdRoot(streams genericclioptions.IOStreams) *cobra.Command {
 	cmd := &cobra.Command{


### PR DESCRIPTION
Hey, 

first of all, thanks for the cool `kubectl` plugin 🎉 . After using this plugin for a while, I thought it might be nice to always enable the fzf preview with an environment variable instead of having to write `--preview` or `-P`.

I don't know if the env-var name is quite fitting, but feel free to comment on this :)